### PR TITLE
Fix: Prevent GitHub shortcut from triggering on Cmd/Ctrl + C

### DIFF
--- a/src/components/hero.astro
+++ b/src/components/hero.astro
@@ -55,7 +55,10 @@ function handleHeroKeyKeyPress(event) {
         activeElement.tagName === 'TEXTAREA'
   )
 
-  if (isInputActive) return
+  if (isInputActive) return;
+
+  // Ignore system shortcuts like Cmd + C / Ctrl + C
+  if (event.metaKey || event.ctrlKey) return;
 
   if (event.key === 'c' || event.key === 'C') {
              // Cliquer sur le bouton GitHub


### PR DESCRIPTION
Added metaKey/ctrlKey checks to keyboard listener to avoid opening the GitHub link when the user performs a copy command.